### PR TITLE
Fix/ie11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.1] - 2019-06-06
 ### Fixed
 - Uses regular functions instead of arrow functions, for IE11 support.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Uses regular functions instead of arrow functions, for IE11 support.
+
 ## [1.1.0] - 2019-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,28 +38,16 @@ It will render:
 
 ### Development
 
-Install `@pika/pack`:
+After installing dependencies, with `yarn`, run:
 
 ```sh
-npm install -g @pika/pack
-```
-
-You can run its build:
-
-```
-pack build
+yarn run build
 ```
 
 ### Publishing
 
-Install `@pika/pack`:
+After installing dependencies, with `yarn`, run:
 
 ```sh
-npm install -g @pika/pack
-```
-
-Run:
-
-```
-pack publish
+yarn run publish
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/css-handles",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "index.js",
   "@pika/pack": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "type": "git",
     "url": "git+https://github.com/vtex/css-handles.git"
   },
+  "scripts": {
+    "build": "pack build",
+    "publish": "pack publish"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,18 @@
 
-export const safelyGetBlockClass = (blockClass: string) =>
-blockClass ? blockClass.split(' ')[0] : ''
+/** TODO: Arrow functions are not being converted to regular functions by Pika,
+ * and thus do not work on IE11. Check if any update on pika/plugin-build-web
+ * changes this behaviour, or change the packager alltogether.
+ * (Keep an eye on https://github.com/pikapkg/builders/pull/52) */
 
-export const generateBlockClass = (baseClass: string, blockClass?: string) =>
-blockClass
-  ? `${baseClass} ${baseClass}--${safelyGetBlockClass(blockClass)}`
-  : baseClass
+export function safelyGetBlockClass(blockClass: string) {
+  blockClass ? blockClass.split(' ')[0] : ''
+}
+
+export function generateBlockClass(baseClass: string, blockClass?: string) {
+  blockClass
+    ? `${baseClass} ${baseClass}--${safelyGetBlockClass(blockClass)}`
+    : baseClass
+}
 
 export interface BlockClass {
   blockClass?: string


### PR DESCRIPTION
Exports regular functions instead of arrow functions, for IE11 support.